### PR TITLE
Upgrade dependencies in tests

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 geo-booleanop = { path = "../lib", features = [] }   # add "debug-booleanop" for debugging
-geo = "0.17"
+geo = "0.19"
 
 # Note: It is crucial to enable arbitrary_precision on serde_json, otherwise
 # JSON parsing isn't exact.

--- a/tests/src/helper.rs
+++ b/tests/src/helper.rs
@@ -135,7 +135,7 @@ pub fn extract_expected_result(feature: &Feature) -> ExpectedResult {
         "xor" => TestOperation::Xor,
         "diff" => TestOperation::DifferenceAB,
         "diff_ba" => TestOperation::DifferenceBA,
-        _ => panic!(format!("Invalid operation: {}", op)),
+        _ => panic!("Invalid operation: {}", op),
     };
 
     let swap_ab_is_broken = properties

--- a/tests/src/possible_intersection_test.rs
+++ b/tests/src/possible_intersection_test.rs
@@ -162,7 +162,7 @@ fn test_on_two_polygons() {
             }
         }
         if !found {
-            panic!(format!("interval {} not found", interval))
+            panic!("interval {} not found", interval);
         }
     }
 }


### PR DESCRIPTION
This upgrades dependencies in tests only. The library itself needs no changes; there's a geo-types dependency that's still fine