### PR TITLE
Switch CI from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Check format
+        run: |
+          cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run clippy
+        run: |
+          cargo clippy -- -D warnings
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run tests
+        run: |
+          cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: rust
-rust:
-- stable
-- beta
-- nightly
-matrix:
-  allow_failures:
-  - rust: nightly
-  fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/21re/rust-geo-booleanop.svg?branch=master)](https://travis-ci.org/21re/rust-geo-booleanop)
+[![Build Status](https://github.com/21re/rust-geo-booleanop/actions/workflows/ci.yml/badge.svg)](https://github.com/21re/rust-geo-booleanop/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/geo-booleanop.svg)](https://crates.io/crates/geo-booleanop)
 
 

--- a/tests/src/bin/run_single_test.rs
+++ b/tests/src/bin/run_single_test.rs
@@ -52,7 +52,7 @@ fn main() {
 
     let filename_in = matches.get_one::<String>("file").unwrap();
     let filename_out = filename_in.clone() + ".generated";
-    fs::copy(&filename_in, &filename_out).expect("Failed to copy file.");
+    fs::copy(filename_in, &filename_out).expect("Failed to copy file.");
 
     run_generic_test_case_with_extra_options(&filename_out, swap_ab);
 


### PR DESCRIPTION
Travis doesn't have free plans anymore.

Switch CI to GitHub Actions